### PR TITLE
Turn on system flags on plugin install

### DIFF
--- a/src/EventSubscriber/PluginPostActivateEventSubscriber.php
+++ b/src/EventSubscriber/PluginPostActivateEventSubscriber.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace BetterPayment\EventSubscriber;
+
+use BetterPayment\BetterPayment;
+use Shopware\Core\Framework\Plugin\Event\PluginPostActivateEvent;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class PluginPostActivateEventSubscriber implements EventSubscriberInterface
+{
+    private SystemConfigService $systemConfigService;
+
+    public function __construct(SystemConfigService $systemConfigService)
+    {
+        $this->systemConfigService = $systemConfigService;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PluginPostActivateEvent::class => 'onPluginActivate',
+        ];
+    }
+
+    public function onPluginActivate(PluginPostActivateEvent $event): void
+    {
+        if ($event->getPlugin()->getBaseClass() == BetterPayment::class)
+        {
+            $this->systemConfigService->set('core.loginRegistration.showPhoneNumberField', true);
+            $this->systemConfigService->set('core.loginRegistration.showAccountTypeSelection', true);
+        }
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -75,6 +75,11 @@
             <tag name="kernel.event_subscriber"/>
         </service>
 
+        <service id="BetterPayment\EventSubscriber\PluginPostActivateEventSubscriber">
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="BetterPayment\EventSubscriber\MappingRegisterCustomer">
             <tag name="kernel.event_subscriber"/>
         </service>


### PR DESCRIPTION
Instead of plugin install, plugin activate use case is chosen to turn on system flags. This is not implemented directly inside plugin activate method, but using Event Subscriber to keep base plugin class clean for code readability. Related event is called: `PluginPostActivateEvent`